### PR TITLE
Fixed css version number in index-with-bridal-party.html

### DIFF
--- a/index-with-bridal-party.html
+++ b/index-with-bridal-party.html
@@ -22,7 +22,7 @@
         <link rel="shortcut icon" href="favicon.ico?v=1">
 
         <link rel="stylesheet" href="css/normalize.min.css">
-        <link rel="stylesheet" href="css/main-1.5.css">
+        <link rel="stylesheet" href="css/main-1.6.css">
 
         <script src="js/vendor/modernizr-2.6.2-respond-1.1.0.min.js"></script>
     </head>


### PR DESCRIPTION
The example site's css is slightly out of date and trying to link to 1.5 rather than 1.6.